### PR TITLE
fix: read entry body via single-entity endpoint (list omits body since elabFTW 5.6.0)

### DIFF
--- a/src/elab_app/utils.py
+++ b/src/elab_app/utils.py
@@ -29,10 +29,8 @@ def append_to_experiment_old(api_client, exp_id, content):
     content = ': '.join([now.strftime("%Y-%m-%d_%H-%M-%S"),content]) # add time stamp
     content = content.replace('\n','<br>') # add line break
     
-    # get current content of the experiment
-    names, ids, exps = get_experiments(api_client)
-    ind = ids.index(exp_id)
-    current_content = exps[ind].body
+    # get current content of the experiment (single-entity endpoint gives full body)
+    current_content = elabapi_python.ExperimentsApi(api_client).get_experiment(id=exp_id).body
     
     # add new content
     new_content = '<br>'.join([current_content,content])
@@ -72,12 +70,14 @@ def append_to_experiment(api_client, exp_id, content, custom_timestamp=None, ent
     n_tables   = 0
     total_rows = 0
     try:
-        # get current content of the entry
+        # get current content of the entry via the SINGLE-entity endpoint.
+        # The list endpoint no longer includes 'body' since elabFTW 5.6.0, so
+        # reading it from the list (entries[..].body) yields '' and would
+        # OVERWRITE the whole entry on the following patch.
         if entity_type == 'items':
-            names, ids, entries = get_items(api_client)
+            current_content = elabapi_python.ItemsApi(api_client).get_item(id=exp_id).body or ''
         else:
-            names, ids, entries = get_experiments(api_client)
-        current_content = entries[ids.index(exp_id)].body or ''
+            current_content = elabapi_python.ExperimentsApi(api_client).get_experiment(id=exp_id).body or ''
 
         new_row = (timestamp, content_html, initials, LOG_SCHEMA_VERSION)
         new_content, inserted, skipped, n_tables = _consolidate(current_content, [new_row])
@@ -569,10 +569,10 @@ def bulk_append_to_experiment(api_client, exp_id, new_rows, entity_type='experim
     skipped  = 0
     try:
         if entity_type == 'items':
-            names, ids, entries = get_items(api_client)
+            # single-entity endpoint returns the full body (list does not since 5.6.0)
+            current_content = elabapi_python.ItemsApi(api_client).get_item(id=exp_id).body or ''
         else:
-            names, ids, entries = get_experiments(api_client)
-        current_content = entries[ids.index(exp_id)].body or ''
+            current_content = elabapi_python.ExperimentsApi(api_client).get_experiment(id=exp_id).body or ''
 
         new_content, inserted, skipped, _ = _consolidate(current_content, new_rows)
 


### PR DESCRIPTION
## Problem
Since elabFTW 5.6.0 the LIST endpoint no longer includes the 'body' field in
experiment/resource responses. The full body is only returned by the
single-entity endpoints GET /experiments/{id} and /items/{id}.

append_to_experiment(), bulk_append_to_experiment() and append_to_experiment_old()
read the current entry body from the list (get_experiments/get_items ->
entries[..].body). Since 5.6.0 that read returns '' and the subsequent
patch_experiment()/patch_item() OVERWRITES the whole entry with only the new
log row, losing the original main text.

## Fix
Fetch the current body via the single-entity API methods (get_experiment(id) /
get_item(id)), which return the full body, so appending now correctly merges
into the existing content instead of replacing it.

## Notes
- Discovery (get_experiments/get_items) is unchanged: it only reads title/id,
  which the compact list still provides.
- Tested live against an elabFTW 5.6.12 instance: two sequential appends both
  survive; the original main text is preserved.